### PR TITLE
Update Menu.vue. Extra checking in documentClick function

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -99,10 +99,15 @@
             this.isSideBarOpen = false;
           }
         },
-        documentClick(e) {
+	    documentClick(e) {
           let element = document.querySelector('.bm-burger-button');
-          let target = e.target;
+          let target = null;
+          if(e && e.target) {
+              target = e.target;
+            }
+
           if (
+            element && 
             element !== target &&
             !element.contains(target) &&
             e.target.className !== 'bm-menu' &&
@@ -111,7 +116,7 @@
             this.closeMenu();
           }
         }
-      },
+	  },
 
       mounted() {
         if (!this.disableEsc) {


### PR DESCRIPTION
I had a problem with the menu in some complex pages.
Situation: the menu is present on the page, but hidden (not visible) and the Document onClick event bubbles to the menu component and caused the error because it was not related to the menu itself.
The simple fix eliminated the problem: just make the extra checking in documentClick function (menu.vue file)