### PR TITLE
modify closeOnNavigation not to close when non-link element is clicked

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -124,7 +124,8 @@
             element &&
             this.hasClass(target,'bm-menu') &&
             this.isSideBarOpen &&
-            this.closeOnNavigation
+            this.closeOnNavigation && 
+            target.parentNode.tagName === "A"
           ) {
             this.closeMenu();
           }


### PR DESCRIPTION
This is useful when you want to put nested links such as under dropdown inside the menu.
You don't want to close it when user clicks the parent dropdown. So restrict the condition to close as its parent node is A tag.